### PR TITLE
Add file writing and Morph LLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,127 @@ Give your OpenClaw agents access to a 4-agent swarm with ~2M token context for c
 
 ## Features
 
+<<<<<<< HEAD
 - **4-Agent Swarm** — Grok 4.20 coordinates multiple agents for deeper analysis
 - **Massive Context** — ~2M token window, handles entire codebases
 - **5 Modes** — Analyze, Refactor, Code, Reason, Orchestrate
 - **Tool Passthrough** — Pass OpenAI-format tool schemas for function calling
 - **Timeout Safety** — Process-level timeout enforcement prevents hangs
+=======
+You've been building with AI coding agents for a while now. They're great — they can write features, refactor modules, analyze codebases. But there's always been this ceiling. The models they run on are designed for single-turn conversations. They can collaborate with themselves behind the scenes to think through complex problems.
+
+**Enter Grok 4.20 Multi-Agent Beta.**
+
+It's different. Instead of one model responding, it's *four agents coordinating* in real-time. An orchestrator, specialists, critics — all working together to break down your request and reason through it from multiple angles. It can hold ~2M tokens of context — that's entire codebases in a single request.
+
+**The Problem:**
+
+Grok 4.20 is groundbreaking, but it doesn't play nicely with current coding tools. Claude Code doesn't have a Grok integration. OpenClaw's tooling system doesn't support multi-agent swarms. If you wanted to use Grok, you'd have to hack together custom scripts or modify your platform's core components. Not ideal.
+
+**The Solution:**
+
+This plugin bridges that gap. It makes Grok 4.20 available as a tool that any agent in Claude Code or OpenClaw can call. No core modifications, no hacking — just install and go.
+
+Now when your agent needs deep codebase analysis, large-scale refactoring, or complex reasoning, it can delegate to Grok's swarm and get back the kind of coordinated, multi-perspective thinking that single models can't deliver.
+
+---
+
+## File Writing Capabilities
+
+Grok Swarm can now **write files directly** from code blocks in its responses. This solves the context flooding problem — Grok writes files to disk, and only a brief summary returns to your agent.
+
+### How It Works
+
+Grok responses with code blocks like:
+````
+```python src/auth.py
+import jwt
+...
+```
+````
+
+Are automatically parsed and written to the output directory.
+
+### Usage
+
+| Command | Behavior |
+|---------|----------|
+| `--output-dir ./src` | Preview files (dry-run) |
+| `--apply --output-dir ./src` | Write files to `./src` |
+| `--apply --execute "make test"` | Write files, then run tests |
+
+### Example Workflow
+
+```bash
+# Ask Grok to generate a module and write it
+python -m src.bridge.cli code \
+  --prompt "Write a FastAPI auth module with JWT" \
+  --output-dir ./src \
+  --apply
+
+# Then run tests
+python -m src.bridge.cli code \
+  --prompt "Refactor auth to use async" \
+  --apply --execute "pytest tests/" \
+  --output-dir ./src
+```
+
+### Morph LLM Integration
+
+For **partial file edits** (not full replacement), use the `--use-morph` flag:
+
+```bash
+python -m src.bridge.cli refactor \
+  --prompt "Convert this function to async" \
+  --use-morph --apply
+```
+
+This requires Morph LLM MCP installed:
+
+```bash
+claude mcp add morphllm
+```
+
+---
+
+## Known Limitations
+
+> **Note:** When using `--apply`, Grok Swarm parses code blocks and writes files. For targeted edits within existing files, use `--use-morph` (requires Morph LLM MCP).
+
+### Why This Matters
+
+Grok can hold ~1.5M tokens of context and generate ~350K token responses. If that entire response floods back through your orchestrator's context window, you've just wasted precious tokens and slowed down your agent.
+
+```text
+Current Flow:
+Files (1.5M tokens) → Grok → Full response (376K) → Orchestrator (flooded!)
+
+Ideal Flow:
+Files (1.5M tokens) → Grok → Writes files + brief summary → Orchestrator (clean)
+```
+
+### Current Use Cases
+
+Grok Swarm now supports **direct file writing**:
+- ✅ **Code generation with file output** — Grok writes files directly
+- ✅ **Codebase analysis** — Security audits, architecture reviews
+- ✅ **Refactoring with partial edits** — Use `--use-morph` for targeted changes
+- ✅ **Complex reasoning** — Research synthesis, decision making
+
+The `--apply` flag makes Grok write files to disk. Combined with `--execute`, you can build generate → test workflows.
+
+---
+
+## What It Does
+
+| Feature | Why It Matters |
+|----------|------------------|
+| **4-Agent Coordination** | Multiple perspectives on every request |
+| **2M Token Context** | Holds entire codebases without truncation |
+| **5 Task Modes** | Analyze, Refactor, Generate, Reason, Orchestrate |
+| **Dual Platform** | Works in both Claude Code and OpenClaw |
+| **Zero Core Changes** | Drop-in tool, no platform modifications |
+>>>>>>> 574902f (Add file writing and Morph LLM integration)
 
 ---
 

--- a/platforms/claude/skills/grok-swarm/SKILL.md
+++ b/platforms/claude/skills/grok-swarm/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: grok-swarm
+description: Multi-agent intelligence powered by Grok 4.20 via OpenRouter. Use for codebase analysis, refactoring, code generation, and complex reasoning.
+author: OpenClaw
+version: 1.1.0
+---
+
+# Grok Swarm
+
+Give Claude Code access to a 4-agent swarm with ~2M token context for powerful code analysis, refactoring, and reasoning.
+
+## Setup (One-Time)
+
+```bash
+# 1. Install the CLI
+pip install -e .
+
+# 2. Configure your API key
+./scripts/setup.sh
+```
+
+**Get an OpenRouter API key at:** https://openrouter.ai/keys
+
+## Modes
+
+| Mode | Description |
+|------|-------------|
+| `refactor` | Improve code quality while preserving behavior |
+| `analyze` | Security, bug, and architecture audit |
+| `code` | Generate clean, production-ready code |
+| `reason` | Collaborative multi-perspective reasoning |
+
+## Basic Usage
+
+```
+/grok-swarm:refactor Convert this to async/await
+/grok-swarm:analyze Find security vulnerabilities in auth/
+/grok-swarm:code Write a FastAPI endpoint for user registration
+/grokwarm:reason Compare microservices vs monolith for this project
+```
+
+## File Writing Modes
+
+### Dry-Run (Preview Only)
+
+Generate code and preview what files would be created:
+
+```
+/grok-swarm:code Write a FastAPI user endpoint --output-dir ./src
+```
+
+This shows the code blocks Grok returns without writing anything to disk.
+
+### Apply Mode (Write Files)
+
+Use `--apply` to actually write the generated files:
+
+```
+/grok-swarm:code Write a FastAPI user endpoint --output-dir ./src --apply
+```
+
+Files are written based on code block headers (e.g., `python src/routes/users.py`).
+
+### Execute After Generation
+
+Use `--execute` to run a command after Grok responds:
+
+```
+/grok-swarm:refactor Modernize auth/ --output-dir ./auth --apply --execute "pytest tests/"
+```
+
+This is useful for generate → test workflows.
+
+## Morph LLM Integration
+
+For partial file edits (not full file replacement), use the `--use-morph` flag:
+
+```
+/grok-swarm:refactor Convert this function to async --use-morph --apply
+```
+
+This requires Morph LLM MCP to be installed:
+
+```bash
+claude mcp add morphllm
+```
+
+**When to use Morph:**
+- Editing a specific function within a file
+- Making targeted changes without overwriting the entire file
+- Working with large existing files
+
+**When to skip Morph (use default):**
+- Generating entirely new files
+- Working with files you don't have locally
+- Creating multiple files at once
+
+## CLI Flags Reference
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--output-dir` | `-d` | Directory to write files to (used with `--apply`) |
+| `--apply` | `-a` | Actually write files (default is dry-run) |
+| `--execute` | `-e` | Run a command after generation |
+| `--use-morph` | | Use Morph LLM MCP for partial edits |
+| `--timeout` | | API timeout in seconds (default: 120) |
+| `--output` | | Write raw Grok response to file |
+
+## Examples
+
+### Preview new code:
+
+```
+/grok-swarm:code Write a Python CLI with argparse --output-dir ./cli
+```
+
+### Generate and write:
+
+```
+/grok-swarm:code Write a React component --apply --output-dir ./components
+```
+
+### Generate, write, and test:
+
+```
+/grok-swarm:refactor Improve error handling in api/ --apply --execute "make test"
+```
+
+### Analyze with Morph edits:
+
+```
+/grok-swarm:refactor Add type hints to main.py --use-morph --apply
+```
+
+## Requirements
+
+- Python 3.8+
+- `openai` package
+- OpenRouter API key with Grok 4.20 access
+- Optional: Morph LLM MCP (`claude mcp add morphllm`)
+
+## Configuration
+
+API key is stored in `~/.config/grok-swarm/config.json` (mode 600).
+
+To change your API key:
+```bash
+./scripts/setup.sh
+```

--- a/src/bridge/apply.py
+++ b/src/bridge/apply.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+apply.py - Parse code blocks from Grok responses and write them to files.
+
+Handles markdown code blocks with optional language hints and file paths
+from fenced code block attributes.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def parse_code_blocks(markdown_text):
+    blocks = []
+    lines = markdown_text.split('\n')
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        fence_match = re.match(r'^(`{3,})(.*)$', line)
+        if fence_match:
+            fence = fence_match.group(1)
+            header = fence_match.group(2).strip()
+            parts = header.split(None, 1)
+            lang = parts[0] if parts else ""
+            path_hint = parts[1] if len(parts) > 1 else ""
+
+            code_lines = []
+            i += 1
+            while i < len(lines):
+                if re.match(r'^' + re.escape(fence) + r'$', lines[i]):
+                    i += 1  # Skip past closing fence
+                    break
+                code_lines.append(lines[i])
+                i += 1
+
+            code = '\n'.join(code_lines).strip()
+
+            if code:
+                blocks.append({
+                    "language": lang,
+                    "code": code,
+                    "path_hint": path_hint
+                })
+        else:
+            i += 1
+
+    return blocks
+
+
+def infer_filename(block, base_dir):
+    if block.get("path_hint"):
+        return block["path_hint"]
+
+    code = block["code"]
+    lang = block.get("language", "").lower()
+
+    shebang_match = re.match(r'#!\S+/(\S+)', code.split('\n')[0])
+    if shebang_match:
+        name = shebang_match.group(1)
+        return f"script.{name}"
+
+    lang_map = {
+        "python": "output.py", "py": "output.py",
+        "javascript": "output.js", "js": "output.js",
+        "typescript": "output.ts", "ts": "output.ts",
+        "rust": "output.rs", "go": "output.go",
+        "java": "Output.java", "c": "output.c",
+        "cpp": "output.cpp", "c++": "output.cpp",
+        "ruby": "output.rb", "rb": "output.rb",
+        "php": "output.php", "shell": "output.sh",
+        "bash": "output.sh", "sh": "output.sh",
+        "yaml": "output.yaml", "yml": "output.yml",
+        "json": "output.json", "toml": "output.toml",
+        "html": "output.html", "css": "output.css",
+        "sql": "output.sql", "markdown": "output.md",
+        "md": "output.md",
+    }
+
+    if lang in lang_map:
+        return lang_map[lang]
+
+    return "output.txt"
+
+
+def apply_blocks(blocks, base_dir, dry_run=True):
+    base = Path(base_dir)
+    if not dry_run:
+        base.mkdir(parents=True, exist_ok=True)
+
+    files_written = 0
+    files_skipped = 0
+    changes = []
+
+    for block in blocks:
+        filename = infer_filename(block, base_dir)
+        filepath = base / filename
+
+        filepath = filepath.resolve()
+        if not str(filepath).startswith(str(base.resolve())):
+            files_skipped += 1
+            changes.append({
+                "path": str(filepath.relative_to(base)),
+                "action": "skipped",
+                "reason": "path outside base_dir"
+            })
+            continue
+
+        if dry_run:
+            files_skipped += 1
+            action = "would write"
+        else:
+            filepath.parent.mkdir(parents=True, exist_ok=True)
+            filepath.write_text(block["code"])
+            files_written += 1
+            action = "written"
+
+        changes.append({
+            "path": str(filepath.relative_to(base)) if filepath.is_relative_to(base) else str(filepath),
+            "action": action,
+            "language": block.get("language", ""),
+            "size": len(block["code"])
+        })
+
+    return {
+        "files_written": files_written,
+        "files_skipped": files_skipped,
+        "changes": changes
+    }
+
+
+def format_summary(result, base_dir):
+    lines = []
+    lines.append(f"\n{'='*60}")
+    lines.append(f"Applied code blocks to: {base_dir}/")
+    lines.append(f"{'='*60}")
+
+    for change in result["changes"]:
+        path = change["path"]
+        action = change["action"]
+        lang = change.get("language", "")
+        size = change.get("size", 0)
+
+        if action == "skipped":
+            lines.append(f"  SKIPPED: {path} ({change.get('reason', 'n/a')})")
+        else:
+            lines.append(f"  {path} ({lang}, {size:,} chars) - {action}")
+
+    lines.append(f"\nSummary: {result['files_written']} written, {result['files_skipped']} skipped")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse code blocks from Grok responses and write to files")
+    parser.add_argument("input", help="Input markdown file, or - for stdin")
+    parser.add_argument("--base-dir", "-d", default="./grok-output", help="Base directory for output files")
+    parser.add_argument("--yes", "-y", action="store_true", help="Actually write files (default is dry-run)")
+    parser.add_argument("--json", action="store_true", help="Output JSON summary")
+
+    args = parser.parse_args()
+
+    if args.input == "-":
+        markdown_text = sys.stdin.read()
+    else:
+        markdown_text = Path(args.input).read_text()
+
+    blocks = parse_code_blocks(markdown_text)
+
+    if not blocks:
+        print("No code blocks found in input.", file=sys.stderr)
+        sys.exit(0)
+
+    print(f"Found {len(blocks)} code block(s)", file=sys.stderr)
+
+    result = apply_blocks(blocks, args.base_dir, dry_run=not args.yes)
+
+    if args.json:
+        import json
+        print(json.dumps(result, indent=2))
+    else:
+        print(format_summary(result, args.base_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bridge/cli.py
+++ b/src/bridge/cli.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Unified Grok Swarm CLI entrypoint.
+Dispatches to refactor/analyze/code/reason modes using grok_bridge.py logic.
+
+Supports file writing when Grok generates code:
+    --output-dir <path>  Directory to write files to
+    --apply              Actually write files (dry-run by default)
+    --execute <cmd>      Run a command after generation
+    --use-morph          Use Morph LLM MCP for file edits if available
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Support both source and installed package layouts
+current = Path(__file__).parent
+if str(current) not in sys.path:
+    sys.path.insert(0, str(current))
+
+from grok_bridge import call_grok, read_files, MODE_PROMPTS
+
+
+def check_morph_available():
+    """Check if Morph LLM MCP is installed."""
+    try:
+        result = subprocess.run(
+            ["claude", "mcp", "list"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        return "morph" in result.stdout.lower()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def apply_with_morph(blocks, base_dir):
+    """
+    Apply code blocks using Morph LLM MCP edit_file tool.
+    Returns summary dict.
+    """
+    import uuid
+
+    applied = 0
+    errors = []
+
+    for block in blocks:
+        # For Morph, we prefer partial edits. Use path_hint as target.
+        path_hint = block.get("path_hint", "")
+        if not path_hint:
+            # Try to infer from code
+            path_hint = block.get("inferred_path", "output.txt")
+
+        # Build the morphllm_edit_file tool call
+        tool_call = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "tools/call",
+            "params": {
+                "name": "morphllm_edit_file",
+                "arguments": {
+                    "file_path": str(Path(base_dir) / path_hint),
+                    "code": block["code"],
+                    "language": block.get("language", ""),
+                }
+            }
+        }
+
+        # Execute via claude mcp
+        try:
+            result = subprocess.run(
+                ["claude", "mcp", "call", "morphllm", "edit_file",
+                 "--file", str(Path(base_dir) / path_hint),
+                 "--code", block["code"],
+                 "--language", block.get("language", "")],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            if result.returncode == 0:
+                applied += 1
+            else:
+                errors.append(f"{path_hint}: {result.stderr}")
+        except Exception as e:
+            errors.append(f"{path_hint}: {e}")
+
+    return {
+        "applied": applied,
+        "total": len(blocks),
+        "errors": errors
+    }
+
+
+def parse_and_write(result_text, output_dir, dry_run=True):
+    """
+    Parse code blocks from Grok response and write to files.
+    Returns summary string.
+    """
+    from apply import parse_code_blocks, apply_blocks, format_summary
+
+    blocks = parse_code_blocks(result_text)
+
+    if not blocks:
+        return "No code blocks found in response."
+
+    if dry_run:
+        # Just show what would happen
+        base = Path(output_dir)
+        summaries = []
+        for block in blocks:
+            from apply import infer_filename
+            filename = infer_filename(block, output_dir)
+            summaries.append(f"  • {filename} ({block.get('language', 'text')}, {len(block['code']):,} chars)")
+        return f"\nFound {len(blocks)} code block(s) — dry-run:\n" + "\n".join(summaries)
+
+    # Actually write
+    result = apply_blocks(blocks, output_dir, dry_run=False)
+    return format_summary(result, output_dir)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Grok Swarm — Multi-agent CLI powered by Grok 4.20",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "mode",
+        nargs="?",
+        choices=list(MODE_PROMPTS.keys()),
+        default="reason",
+        help="Task mode (default: reason)",
+    )
+    parser.add_argument("--prompt", "-p", required=True, help="Task instruction or question")
+    parser.add_argument("--files", "-f", nargs="*", default=[], help="Files to include as context")
+    parser.add_argument("--system", "-s", help="Override system prompt")
+    parser.add_argument("--tools", "-t", help="Path to OpenAI-format tools JSON")
+    parser.add_argument("--timeout", type=int, default=120, help="Timeout in seconds")
+    parser.add_argument("--output", help="Write raw output to file")
+    parser.add_argument("--output-dir", "--od", "-d",
+                        help="Directory to write generated files (used with --apply)")
+    parser.add_argument("--apply", "-a", action="store_true",
+                        help="Actually write files from code blocks (dry-run by default)")
+    parser.add_argument("--execute", "-e", metavar="CMD",
+                        help="Execute command after generation (shell string)")
+    parser.add_argument("--use-morph", action="store_true",
+                        help="Use Morph LLM MCP for file edits if available")
+
+    args = parser.parse_args()
+
+    if args.mode == "orchestrate" and not args.system:
+        print("ERROR: orchestrate mode requires --system", file=sys.stderr)
+        sys.exit(1)
+
+    # Check Morph availability if --use-morph is set
+    use_morph = False
+    if args.use_morph:
+        if check_morph_available():
+            use_morph = True
+            print("Morph LLM MCP detected — will use for file edits", file=sys.stderr)
+        else:
+            print("WARNING: --use-morph set but Morph LLM MCP not found", file=sys.stderr)
+            print("  Install with: claude mcp add morphllm", file=sys.stderr)
+
+    context = read_files(args.files) if args.files else ""
+
+    if args.files:
+        print(f"Read {len(args.files)} file(s) — {len(context):,} chars", file=sys.stderr)
+
+    # Parse tools if provided
+    tools = None
+    if args.tools:
+        import json
+        with open(args.tools, 'r') as f:
+            tools = json.load(f)
+
+    print(f"Calling Grok 4.20 (mode={args.mode}, 4 agents)...", file=sys.stderr)
+
+    start = time.time()
+    result = call_grok(
+        prompt=args.prompt,
+        mode=args.mode,
+        context=context,
+        system_override=args.system,
+        tools=tools,
+        timeout=args.timeout,
+    )
+    elapsed = time.time() - start
+
+    # Handle JSON tool call responses
+    response_data = None
+    if result.startswith("{") and '"tool_calls"' in result:
+        try:
+            response_data = json.loads(result)
+            result = response_data.get("content", result)
+        except json.JSONDecodeError:
+            pass
+
+    # File writing logic
+    if args.apply or args.output_dir:
+        output_dir = args.output_dir or "./grok-output"
+
+        if use_morph and args.apply:
+            # Use Morph LLM for edits
+            from apply import parse_code_blocks
+            blocks = parse_code_blocks(result)
+
+            if not blocks:
+                print("\nNo code blocks found to apply via Morph.", file=sys.stderr)
+            else:
+                morph_result = apply_with_morph(blocks, output_dir)
+                print(f"\nApplied {morph_result['applied']}/{morph_result['total']} edits via Morph LLM",
+                      file=sys.stderr)
+                if morph_result['errors']:
+                    for err in morph_result['errors']:
+                        print(f"  Error: {err}", file=sys.stderr)
+        else:
+            # Use direct file writing
+            summary = parse_and_write(result, output_dir, dry_run=not args.apply)
+            print(summary, file=sys.stderr)
+
+    # Write raw output if requested
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(result)
+        print(f"Output written to {args.output}", file=sys.stderr)
+
+    # Execute command if requested
+    if args.execute:
+        print(f"\nExecuting: {args.execute}", file=sys.stderr)
+        exec_result = subprocess.run(
+            args.execute,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=300
+        )
+        if exec_result.stdout:
+            print(exec_result.stdout)
+        if exec_result.stderr:
+            print(exec_result.stderr, file=sys.stderr)
+        if exec_result.returncode != 0:
+            print(f"Command exited with code {exec_result.returncode}", file=sys.stderr)
+            sys.exit(exec_result.returncode)
+
+    # Output the raw response to stdout (unless we wrote files and nothing else)
+    if not args.output and not args.execute:
+        print(result)
+
+    print(f"\nCompleted in {elapsed:.1f}s", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add apply.py for parsing code blocks and writing files to disk
- Add --output-dir, --apply, --execute, --use-morph flags to cli.py
- --apply writes code blocks to files (dry-run by default)
- --execute runs a command after generation
- --use-morph detects Morph LLM MCP and uses it for partial edits
- Update SKILL.md with new flags and usage examples
- Update README.md with file writing capabilities section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file writing capabilities with `--output-dir`, `--apply`, and `--execute` command-line flags
  * Introduced Morph LLM integration for partial file edits via `--use-morph` flag
  * New Claude Code skill for Grok 4.20 multi-agent swarm with `refactor`, `analyze`, `code`, and `reason` modes

* **Documentation**
  * Enhanced README with expanded Grok 4.20 features, workflow examples, and known limitations
  * Added new SKILL.md documentation for Claude Code skill setup and operating modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->