### PR TITLE
fix: task positional arg and output_dir in plugin

### DIFF
--- a/src/agent/grok_agent.py
+++ b/src/agent/grok_agent.py
@@ -617,13 +617,13 @@ Examples:
   python3 grok_agent.py --task "refactor auth module" --target ./src/auth
 
   # Apply changes
-  python3 grok_agent.py --task "refactor auth module" --target ./src/auth --apply
+  python3 grok_agent.py "refactor auth module" --target ./src/auth --apply
 
   # With verification
-  python3 grok_agent.py --task "add tests" --target ./src --apply --verify-cmd "pytest"
+  python3 grok_agent.py "add tests" --target ./src --apply --verify-cmd "pytest"
 
   # OpenClaw platform
-  python3 grok_agent.py --platform openclaw --task "analyze security" --target .
+  python3 grok_agent.py --platform openclaw "analyze security" --target .
         """
     )
     parser.add_argument("--platform", choices=["claude", "openclaw"], default="claude",
@@ -638,7 +638,7 @@ Examples:
                        help="Command to run for verification (e.g., pytest)")
     parser.add_argument("--output-dir",
                        help="Output directory for new files (existing files remain in target)")
-    parser.add_argument("--task", "-t", required=True, dest="task",
+    parser.add_argument("task",
                        help="Natural language task instruction")
 
     args = parser.parse_args()

--- a/src/plugin/grok_agent_plugin.ts
+++ b/src/plugin/grok_agent_plugin.ts
@@ -33,6 +33,9 @@ const GrokAgentSchema = Type.Object({
   verify_cmd: Type.Optional(
     Type.String({ description: "Command to run for verification (e.g., pytest)" }),
   ),
+  output_dir: Type.Optional(
+    Type.String({ description: "Output directory for new files" }),
+  ),
 });
 
 export default function (api: any) {
@@ -82,6 +85,10 @@ export default function (api: any) {
 
           if (params.verify_cmd) {
             args.push("--verify-cmd", params.verify_cmd);
+          }
+
+          if (params.output_dir) {
+            args.push("--output-dir", params.output_dir);
           }
 
           args.push("--", params.task);


### PR DESCRIPTION
## Summary
- Change `--task` from named argument to positional in `grok_agent.py` for consistency with how plugin/command pass the argument
- Add `output_dir` parameter to `grok_swarm_agent` tool schema in OpenClaw plugin
- Pass `output_dir` through to agent subprocess

## Changes
- `src/agent/grok_agent.py`: Task is now positional, updated docstring examples
- `src/plugin/grok_agent_plugin.ts`: Added `output_dir` to GrokAgentSchema and args

## Test
Verified agent works:
```
python3 src/agent/grok_agent.py --target .sandbox "list all tasks"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)